### PR TITLE
Laravel 7 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "formulafolios/docusign",
+    "name": "tjphippen/docusign",
     "description": "DocuSign Rest API Wrapper for Laravel.",
     "keywords": [
         "laravel",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tjphippen/docusign",
+    "name": "formulafolios/docusign",
     "description": "DocuSign Rest API Wrapper for Laravel.",
     "keywords": [
         "laravel",
@@ -9,7 +9,7 @@
         "documents",
         "envelope"
     ],
-    "homepage": "https://github.com/tjphippen/docusign",
+    "homepage": "https://github.com/formulafolios/docusign",
     "license": "MIT",
     "authors": [
         {
@@ -29,13 +29,13 @@
     },
     "autoload": {
         "psr-4": {
-            "Tjphippen\\Docusign\\": "src/"
+            "Formulafolios\\Docusign\\": "src/"
         }
     },
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/tjphippen/docusign"
+            "url": "https://github.com/formulafolios/docusign"
         }
     ],
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,13 @@
     },
     "autoload": {
         "psr-4": {
-            "Formulafolios\\Docusign\\": "src/"
+            "Tjphippen\\Docusign\\": "src/"
         }
     },
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/formulafolios/docusign"
+            "url": "https://github.com/tjphippen/docusign"
         }
     ],
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,15 @@
 {
-    "name": "tjphippen/docusign",
+    "name": "formulafolios/docusign",
     "description": "DocuSign Rest API Wrapper for Laravel 5",
-    "keywords": ["laravel", "docusign", "laravel 5", "sign", "documents", "envelope"],
-    "homepage": "https://github.com/tjphippen/docusign",
+    "keywords": [
+        "laravel",
+        "docusign",
+        "laravel 5",
+        "sign",
+        "documents",
+        "envelope"
+    ],
+    "homepage": "https://github.com/formulafolios/docusign",
     "license": "MIT",
     "authors": [
         {
@@ -12,13 +19,13 @@
         }
     ],
     "require": {
-        "php" : ">=5.4.0",
-        "illuminate/support": "~5.1",
+        "php": ">=7.2.0",
+        "illuminate/support": "^7.0",
         "guzzlehttp/guzzle": "~6.0",
-        "laravel/framework": "5.*"
+        "laravel/framework": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "4.*"
+        "phpunit/phpunit": "8.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "formulafolios/docusign",
-    "description": "DocuSign Rest API Wrapper for Laravel 5",
+    "name": "tjphippen/docusign",
+    "description": "DocuSign Rest API Wrapper for Laravel.",
     "keywords": [
         "laravel",
         "docusign",
@@ -9,7 +9,7 @@
         "documents",
         "envelope"
     ],
-    "homepage": "https://github.com/formulafolios/docusign",
+    "homepage": "https://github.com/tjphippen/docusign",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
Fixes #16 

## Changes

- Upgrades dependencies to make the package compatible with Laravel 7

## Why

My team currently uses this package in our application but we would like to upgrade to Laravel 7 since 5.8 is [no longer being maintained](https://laravel.com/docs/6.x/releases#support-policy).